### PR TITLE
Surf & Paddle proposal

### DIFF
--- a/day_08/surf_paddle/stylesheets/style.css
+++ b/day_08/surf_paddle/stylesheets/style.css
@@ -1,5 +1,7 @@
 body {
 	font-family: 'Open Sans', sans-serif;
+	background-repeat: no-repeat;
+	width: 1300px;
 }
 
 /* ======== Header ========== */


### PR DESCRIPTION
Dawn, 

This is a fork of your 'Surf & Paddle' style.css and no permanent changes have been made. This is only a proposal for a few bug fixes...

Bugs:
1. The background images in the header and footer were repeating...'background-repeat: no-repeat' under body tag, fixed this. 
1. After the background-repeat fix, the background-images in the footer had white space between them...'width: 1300px' under the body tag, fixed this.  (You can also fix this in the html by putting the tags on the same line...this seemed easier though)
2. The left logo picture and the left logo word's (SURF & PADDLE CO. BLOG) needed a little separation... increasing 'padding-left:' to 52px in the .logo h3 tag fixed this.
